### PR TITLE
2 implement pentatonic scale

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,8 +125,8 @@ void changeKey(int newKey) {
 void changeScale() {
   // Cycle through scale options
   currentScale = (currentScale + 1) % (sizeof(scales) / sizeof(scales[0]));
-  if (currentScale == PENTATONIC) {
-    changeMode();
+  if (currentScale == PENTATONIC & currentMode==TRIAD_CHORD) {
+    currentMode == SINGLE_NOTE;
   }
   playArpeggio();  
 }
@@ -165,10 +165,8 @@ void playOrEndNotes(int i, bool noteOn) {
 
 void changeMode() {
   // Cycle through chord modes
-  currentMode = (currentMode + 1) % numModes;
-  if (currentMode == TRIAD_CHORD & currentScale == PENTATONIC) {
-    changeMode();
-  }
+  currentMode = currentScale == PENTATONIC ? (currentMode + 1) % 2 : (currentMode + 1) % numModes;
+
   // Play a note in the new mode for one second
   silence();
   playOrEndNotes(0, true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,7 @@ int arpeggioNotes[][6] = {
   {-12, 0, 4, 7, 12, 16},     // Major
   {-12, 0, 3, 7, 12, 15},     // Minor
   {-12, 0, 3, 7, 10, 15},     // Pentatonic - Minor 7th
-}
+};
 
 // Vector to store chord's notes for playing/ending
 std::vector<int> notes;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,16 +45,16 @@ int key = 60;
 int scales[][8] = {
   {0, 2, 4, 5, 7, 9, 11, 12},   // Major
   {0, 2, 3, 5, 7, 8, 10, 12},   // Minor
-  {0, 3, 5, 6, 7, 10, 12, 15},  // Blues
+  {0, 3, 5, 7, 10, 12, 15, 17},  // Pentatonic
 };
 
-// Currently selected scale - 0: Major, 1: Minor, 2: Blues
+// Currently selected scale - 0: Major, 1: Minor, 2: Pentatonic
 int currentScale = 0;
 
 // Constants to define scales
 const int MAJOR = 0;
 const int MINOR = 1;
-const int BLUES = 2;
+const int PENTATONIC = 2;
 
 // Define current mode - 0: Single note, 1: Power chord, 2: Triad chord
 int currentMode = 0;
@@ -71,8 +71,8 @@ const int TRIAD_CHORD = 2;
 int arpeggioNotes[][6] = {
   {-12, 0, 4, 7, 12, 16},     // Major
   {-12, 0, 3, 7, 12, 15},     // Minor
-  {-12, 0, 3, 7, 10, 15},     // Blues - Minor 7th
-};
+  {-12, 0, 3, 7, 10, 15},     // Pentatonic - Minor 7th
+}
 
 // Vector to store chord's notes for playing/ending
 std::vector<int> notes;
@@ -125,6 +125,9 @@ void changeKey(int newKey) {
 void changeScale() {
   // Cycle through scale options
   currentScale = (currentScale + 1) % (sizeof(scales) / sizeof(scales[0]));
+  if (currentScale == PENTATONIC) {
+    changeMode();
+  }
   playArpeggio();  
 }
 
@@ -138,7 +141,7 @@ void playOrEndNotes(int i, bool noteOn) {
   } 
 
   // Triad chords: Major (0-4-7), Minor (0-3-7), and Diminished (0-3-6)
-  else if (currentMode == TRIAD_CHORD && currentScale != BLUES) {
+  else if (currentMode == TRIAD_CHORD && currentScale != PENTATONIC) {
     int thirdPos = (i + 2) % 7;
     int fifthPos = (i + 4) % 7;
 
@@ -163,6 +166,9 @@ void playOrEndNotes(int i, bool noteOn) {
 void changeMode() {
   // Cycle through chord modes
   currentMode = (currentMode + 1) % numModes;
+  if (currentMode == TRIAD_CHORD & currentScale == PENTATONIC) {
+    changeMode();
+  }
   // Play a note in the new mode for one second
   silence();
   playOrEndNotes(0, true);


### PR DESCRIPTION
### Changed the following:

**Program the Pentatonic Scale**
- 48: Shorten the blues scale into a pentatonic scale and an additional 3rd note at the end instead.
- 57: Change constant name from "BLUES" to "PENTATONIC"
- 74: Changed comment acknowledging Pentatonic scale

**In changeScale(), if new scale is pentatonic and mode is triad, call changeMode() to switch to single note.**
- 128 - 129: Added condition to simply manually set mode instead of using changeMode function given that the currentScale is PENTATONIC and currentMode is TRIAD_CHORD, when cycling through scales. Ensures consistency with what mode it is changed to when a PENTATONIC scale is used with an incompatible mode like TRIAD mode.

**in changeMode() , if the scale is pentatonic, ensure triad mode is skipped.**
- 168 - 169: If currentScale is PENTATONIC, restrict maximum range to SINGLE_NOTE and POWER_CHORD.