### PR TITLE
Feat/3 swap positions of power chord and triad chords

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,7 +126,7 @@ void changeScale() {
   // Cycle through scale options
   currentScale = (currentScale + 1) % (sizeof(scales) / sizeof(scales[0]));
   if (currentScale == PENTATONIC & currentMode==TRIAD_CHORD) {
-    currentMode == SINGLE_NOTE;
+    currentMode = SINGLE_NOTE;
   }
   playArpeggio();  
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,7 +125,7 @@ void changeKey(int newKey) {
 void changeScale() {
   // Cycle through scale options
   currentScale = (currentScale + 1) % (sizeof(scales) / sizeof(scales[0]));
-  if (currentScale == PENTATONIC & currentMode==TRIAD_CHORD) {
+  if (currentScale == PENTATONIC && currentMode==TRIAD_CHORD) {
     currentMode = SINGLE_NOTE;
   }
   playArpeggio();  
@@ -166,7 +166,7 @@ void playOrEndNotes(int i, bool noteOn) {
 void changeMode() {
   // Cycle through chord modes. 
   // If the current scale is Pentatonic AND the current mode is single note, skip to the power chord .
-  currentMode = (currentScale == PENTATONIC) & (currentMode == SINGLE_NOTE) ? POWER_CHORD : (currentMode + 1) % numModes;
+  currentMode = (currentScale == PENTATONIC) && (currentMode == SINGLE_NOTE) ? POWER_CHORD : (currentMode + 1) % numModes;
 
   // Play a note in the new mode for one second
   silence();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,8 +64,8 @@ int numModes = 3;
 
 // Constants to define chord modes
 const int SINGLE_NOTE = 0;
-const int POWER_CHORD = 1;
-const int TRIAD_CHORD = 2;
+const int TRIAD_CHORD = 1;
+const int POWER_CHORD = 2;
 
 // Define arpeggio notes for each scale
 int arpeggioNotes[][6] = {
@@ -164,8 +164,9 @@ void playOrEndNotes(int i, bool noteOn) {
 
 
 void changeMode() {
-  // Cycle through chord modes
-  currentMode = currentScale == PENTATONIC ? (currentMode + 1) % 2 : (currentMode + 1) % numModes;
+  // Cycle through chord modes. 
+  // If the current scale is Pentatonic AND the current mode is single note, skip to the power chord .
+  currentMode = (currentScale == PENTATONIC) & (currentMode == SINGLE_NOTE) ? POWER_CHORD : (currentMode + 1) % numModes;
 
   // Play a note in the new mode for one second
   silence();


### PR DESCRIPTION
### Changed The Following:
- 67 - 68: Swapped the order of Power Chord and Triad Chord.
- 128: Fixed "&" operator and made it "&&"
- 129: Fixed assignment operator, "==" to "=".
- 167 - 169: currentMode to switch to POWER_CHORD when scale is pentatonic and the currentMODE is SINGLE_NOTE. This skips TRIAD_CHORD.